### PR TITLE
add rbenv/bin to path before checking for rbenv executable

### DIFF
--- a/conf.d/rbenv.fish
+++ b/conf.d/rbenv.fish
@@ -1,14 +1,17 @@
-if not command -s rbenv > /dev/null
-    echo "rbenv: command not found. See https://github.com/rbenv/rbenv"
-    exit 1
-end
-
 set -l rbenv_root ''
 if test -z "$RBENV_ROOT"
     set rbenv_root "$HOME/.rbenv"
     set -x RBENV_ROOT "$HOME/.rbenv"
 else
     set rbenv_root "$RBENV_ROOT"
+end
+
+set -x PATH $rbenv_root/bin $PATH
+if not command -s rbenv > /dev/null
+    echo "rbenv: command not found. See https://github.com/rbenv/rbenv"
+    exit 1
+else
+    set --erase RBENV_ROOT
 end
 
 set -x PATH $rbenv_root/shims $PATH


### PR DESCRIPTION
Add rbenv/bin to path before checking for rbenv executable. Otherwise it doesn't work, at least not on my machine...the plugin looks for rbenv and cannot find it because its not in my PATH yet--that's what the plugin is supposed to do!

Similar to the PR for pyenv: https://github.com/fisherman/pyenv/pull/3
